### PR TITLE
Add Nix flake as Option 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,21 @@ cd -
 
 **Important for Terraform Enterprise and Remote Backend Users**: TerraVision automatically forces local backend execution (ignoring remote state) to generate diagrams showing the complete infrastructure definition, not just deltas. This ensures accurate architecture visualization regardless of your configured backend.
 
+### Option 3 - Nix
+
+If you have [Nix](https://nixos.org/download/) installed with flakes enabled, you can enter a development shell with `terravision` and all dependencies available:
+
+```bash
+git clone https://github.com/patrickchugh/terravision.git && cd terravision
+nix develop
+```
+
+This provides `terravision`, `graphviz`, `terraform`, and `git` in your shell. You can also run it directly without cloning:
+
+```bash
+nix run github:patrickchugh/terravision -- draw --source /path/to/terraform --show
+```
+
 ### Try It Out!
 
 Generate your first diagram using our example Terraform code:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769018530,
+        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,103 @@
+{
+  description = "TerraVision - AI-Powered Terraform to Architecture Diagram Generator";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python312;
+
+        pythonPackages = python.pkgs;
+
+        # Wrapper that provides 'terraform' command using opentofu
+        terraformWrapper = pkgs.writeShellScriptBin "terraform" ''
+          exec ${pkgs.opentofu}/bin/tofu "$@"
+        '';
+
+        # Override python-hcl2 to use version 4.3.0 as required by terravision
+        python-hcl2 = pythonPackages.buildPythonPackage rec {
+          pname = "python-hcl2";
+          version = "4.3.0";
+          pyproject = true;
+
+          src = pkgs.fetchPypi {
+            inherit pname version;
+            hash = "sha256-QeN+Kps9Ij2l6OvJnnK0DSMVCH6Wb0WPfqwTx4Mdm54=";
+          };
+
+          build-system = with pythonPackages; [ setuptools setuptools-scm ];
+
+          dependencies = with pythonPackages; [
+            lark
+          ];
+
+          doCheck = false;
+        };
+
+        terravision = pythonPackages.buildPythonApplication {
+          pname = "terravision";
+          version = "0.10.2";
+          pyproject = true;
+
+          src = ./.;
+
+          build-system = [ pythonPackages.poetry-core ];
+
+          dependencies = with pythonPackages; [
+            click
+            gitpython
+            graphviz
+            tqdm
+            python-hcl2
+            pyyaml
+            debugpy
+            ipaddr
+            ollama
+            requests
+            typing-extensions
+            tomli
+          ];
+
+          # Graphviz binary and terraform wrapper are needed at runtime
+          makeWrapperArgs = [
+            "--prefix" "PATH" ":" "${pkgs.lib.makeBinPath [ pkgs.graphviz terraformWrapper ]}"
+          ];
+
+          # Skip tests during build
+          doCheck = false;
+
+          meta = with pkgs.lib; {
+            description = "Terraform Architecture Visualizer";
+            homepage = "https://github.com/patrickchugh/terravision";
+            license = licenses.agpl3Only;
+            mainProgram = "terravision";
+          };
+        };
+
+      in {
+        packages = {
+          default = terravision;
+          terravision = terravision;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            terravision
+            pkgs.graphviz
+            terraformWrapper
+            pkgs.git
+          ];
+
+          shellHook = ''
+            echo "TerraVision development environment"
+            echo "Run 'terravision --help' to get started"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
#  Add third installation option (not docker, not native, but nix)

I don't like installing python stuff on my host machine, and I also think docker is overkill. Nix is a nice sweet spot between the two, since it has filesystem isolation like docker, but without all the process namespace overhead.

## Type of Change

* [ ] Bug Fix
* [x] New Feature
* [ ] Refactor
* [x] Documentation

## Checklist

All Submissions:
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you written Documentation/Tests?
* [x] Have you done your own code-review?
* [ ] Have you disclosed any use of AI tools and models with their version?

## AI Assistance Declaration
- Tools used: Claude Code
- Model: Claude Opus 4.5
- Scope: Generated Nix flake

### Checklist for Changes to Core Features:

* [ ] Have you discussed any major revamp with a reviewer/maintainer first? (It's okay to just raise a PR directly for minor bugfixes)
* [x] Have you ensured your PR is focused on one major improvement and is not trying to do too many changes at once? For example:
      Bad : Adding support for GCP and Azure system wide
      Good: Just adding Azure resource handler for VNets
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable, and made sure the new tests PASS? (no, but I tested it using Determinate Nix 3.11.2 and it works)
* [x] Have you successfully run all previous system wide tests with your changes locally?
