### PR TITLE
fix: Fix KeyError in reverse_relations when handling module resources

### DIFF
--- a/modules/graphmaker.py
+++ b/modules/graphmaker.py
@@ -349,9 +349,12 @@ def reverse_relations(tfdata: Dict[str, Any]) -> Dict[str, Any]:
                 > 0
             )
             if reverse_origin:
+                if not tfdata["graphdict"].get(c):
+                    tfdata["graphdict"][c] = list()
                 if n not in tfdata["graphdict"][c]:
                     tfdata["graphdict"][c].append(n)
-                tfdata["graphdict"][node].remove(c)
+                if c in tfdata["graphdict"].get(n, []):
+                    tfdata["graphdict"][n].remove(c)
 
     return tfdata
 


### PR DESCRIPTION
# Fix KeyError in reverse_relations when handling module resources

## Problem
Terravision was crashing with a `KeyError` when processing Terraform configurations that contain resources defined in submodules with cross-references between module resources and root resources.

**Error:**
```
KeyError: 'aws_iam_role.cloudwatch_trigger_ssm_role'
```

**Stack trace:**
```python
File "modules/graphmaker.py", line 354, in reverse_relations
    tfdata["graphdict"][node].remove(c)
    ~~~~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'aws_iam_role.cloudwatch_trigger_ssm_role'
```

## Root Cause
In the `reverse_relations` function (line 354), the code was using the wrong variable name as the dictionary key:

```python
tfdata["graphdict"][node].remove(c)
```

The issue is that:
- `node` = resource name **without** module prefix (e.g., `aws_iam_role.cloudwatch_trigger_ssm_role`)
- `n` = **full** resource name with module prefix (e.g., `module.build.aws_iam_role.cloudwatch_trigger_ssm_role`)

The `graphdict` keys are stored with their full module paths (`n`), but the code was attempting to access the dictionary using the shortened name (`node`), causing a KeyError when the resource was defined in a module.

## Solution
Updated line 352-354 in `modules/graphmaker.py` to:

1. **Use the correct variable**: Changed from `node` to `n` to match the actual dictionary key
2. **Add safety check**: Ensure the graphdict key exists before accessing
3. **Verify list membership**: Only attempt removal if the item exists in the list

**Before:**
```python
if reverse_origin:
    if n not in tfdata["graphdict"][c]:
        tfdata["graphdict"][c].append(n)
    tfdata["graphdict"][node].remove(c)  # ❌ Wrong key: 'node' doesn't exist
```

**After:**
```python
if reverse_origin:
    if not tfdata["graphdict"].get(c):
        tfdata["graphdict"][c] = list()
    if n not in tfdata["graphdict"][c]:
        tfdata["graphdict"][c].append(n)
    if c in tfdata["graphdict"].get(n, []):
        tfdata["graphdict"][n].remove(c)  # ✅ Correct key with safety checks
```

## Testing
Tested with a Terraform configuration containing:
- Root-level resources
- Submodule resources (in `build/` directory)
- Cross-references between root and module resources (IAM roles, CloudWatch events, etc.)

**Result:** Successfully generated diagram without errors.

## Impact
- **Fixes**: KeyError crashes when processing modules with cross-resource references
- **Improves**: Robustness by adding defensive checks for dictionary access
- **No breaking changes**: Only fixes edge case handling; existing functionality unchanged
