### PR TITLE
fix: prevent infinite loop in handle_metadata_vars when variable references cycle

### DIFF
--- a/modules/interpreter.py
+++ b/modules/interpreter.py
@@ -171,7 +171,12 @@ def handle_metadata_vars(tfdata: Dict[str, Any]) -> Dict[str, Any]:
     for resource, attr_list in tfdata["meta_data"].items():
         for key, orig_value in attr_list.items():
             value = str(orig_value)
-            # Iteratively resolve all variable references
+            # Iteratively resolve all variable references.
+            # Track seen values to detect cycles (e.g. local.A → local.B → local.A)
+            # where find_replace_values keeps producing a different string each
+            # iteration without ever fully resolving it. The existing `value ==
+            # old_value` guard only catches fixed points, not cycles.
+            _seen_values: set = set()
             while (
                 (
                     "var." in value
@@ -185,6 +190,15 @@ def handle_metadata_vars(tfdata: Dict[str, Any]) -> Dict[str, Any]:
                 and key != "depends_on"
                 and key != "original_count"
             ):
+                if value in _seen_values:
+                    click.echo(
+                        click.style(
+                            f"   WARNING: Cannot fully resolve {resource}.{key}, unresolved references remain",
+                            fg="yellow",
+                        )
+                    )
+                    break
+                _seen_values.add(value)
                 mod = attr_list["module"]
                 old_value = value
                 value = find_replace_values(value, mod, tfdata)


### PR DESCRIPTION
## What

`handle_metadata_vars` hangs indefinitely when `find_replace_values` produces a cycling sequence of values (e.g. `local.A` → `local.B` → `local.A` → ...).

The existing guard only breaks when `value == old_value` (a fixed point). Cycles are different: the value changes each iteration and never repeats *consecutively*, so the break is never reached.

## Root cause

```python
while ("local." in value or "var." in value or ...):
    old_value = value
    value = find_replace_values(value, mod, tfdata)
    if value == old_value:  # only catches fixed points, not cycles
        break
```

If `find_replace_values` expands `local.A` to something containing `local.B`, then `local.B` back to something containing `local.A`, the loop runs forever with no output.

## Fix

Add a `_seen_values` set that tracks every value encountered in the current resolution pass. If the same value appears again, we've detected a cycle — emit the existing "unresolved references remain" warning and break.

```python
_seen_values: set = set()
while (...):
    if value in _seen_values:
        # cycle detected
        click.echo(WARNING...)
        break
    _seen_values.add(value)
    ...
```

## How I found it

Running `terravision draw` against a Terraform project that uses a Cognito module with a `local.lambda_arn` map. The module defines optional lambda ARN locals that are conditionally populated — when the lambda isn't configured, the reference chain cycles instead of resolving to a terminal value. Terravision printed all the "Processing resources" entries, then hung silently forever with 100% CPU.

## Tested

Confirmed fix resolves the hang on the reproducing project. The diagram generates successfully after the patch.