### PR TITLE
Feature/opentofu support

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -99,6 +99,7 @@ terravision draw [OPTIONS]
 | `--iconsize` | Icon size in pixels | `128` | `--iconsize 200` |
 | `--planfile` | Pre-generated Terraform plan JSON | None | `--planfile plan.json` |
 | `--graphfile` | Pre-generated Terraform graph DOT | None | `--graphfile graph.dot` |
+| `--engine` | Infra engine binary: `terraform`, `tofu` (OpenTofu), or `auto` (detect) | `auto` | `--engine tofu` |
 | `--debug` | Enable debug output | False | `--debug` |
 
 ### `terravision visualise`
@@ -134,6 +135,7 @@ terravision visualise [OPTIONS]
 | `--iconsize` | Icon size in pixels | `128` | `--iconsize 200` |
 | `--planfile` | Pre-generated Terraform plan JSON | None | `--planfile plan.json` |
 | `--graphfile` | Pre-generated Terraform graph DOT | None | `--graphfile graph.dot` |
+| `--engine` | Infra engine binary: `terraform`, `tofu` (OpenTofu), or `auto` (detect) | `auto` | `--engine tofu` |
 | `--debug` | Enable debug output | False | `--debug` |
 
 **Interactive features in the generated HTML:**
@@ -186,6 +188,7 @@ terravision graphdata [OPTIONS]
 | `--show_services` | Show only unique services list | False | `--show_services` |
 | `--planfile` | Pre-generated Terraform plan JSON | None | `--planfile plan.json` |
 | `--graphfile` | Pre-generated Terraform graph DOT | None | `--graphfile graph.dot` |
+| `--engine` | Infra engine binary: `terraform`, `tofu` (OpenTofu), or `auto` (detect) | `auto` | `--engine tofu` |
 
 ---
 
@@ -387,6 +390,31 @@ These adjustments apply uniformly to all providers (AWS, Azure, GCP) and all out
 ---
 
 ## Advanced Usage
+
+### OpenTofu
+
+TerraVision works with [OpenTofu](https://opentofu.org) as a drop-in alternative to Terraform — both share an identical CLI for the commands TerraVision relies on (`init`, `workspace`, `plan`, `show -json`, `graph`).
+
+By default (`--engine auto`) TerraVision uses the `terraform` binary if it is on your `PATH`, falling back to `tofu` (OpenTofu) otherwise. Force a specific engine with `--engine`:
+
+```bash
+# Force OpenTofu
+terravision draw --source ./path-to-your-terraform --engine tofu
+
+# Force Terraform (skip autodetection)
+terravision draw --source ./path-to-your-terraform --engine terraform
+```
+
+The `--engine` flag is available on `draw`, `visualise`, and `graphdata`. OpenTofu, like Terraform, must be a `v1.x` release.
+
+You can also set the engine via the `TERRAVISION_ENGINE` environment variable (the `--engine` flag takes precedence when both are given). This is handy in CI or on OpenTofu-only hosts where no `terraform` binary is installed:
+
+```bash
+export TERRAVISION_ENGINE=tofu
+terravision draw --source ./path-to-your-terraform
+```
+
+> **Terragrunt note:** when your source is a Terragrunt project, `--engine tofu` switches the direct `init`/`show`/`graph` calls to OpenTofu, but Terragrunt itself still invokes its own configured binary. To make Terragrunt drive OpenTofu, also set `TG_TF_PATH=tofu` (or `TERRAGRUNT_TFPATH=tofu`) in your environment.
 
 ### Multiple Environments
 

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1759,9 +1759,50 @@ def safe_remove_connection(
     return False
 
 
+# Resolved Terraform-compatible binary: 'terraform' or 'tofu' (OpenTofu).
+# Set by the CLI --engine flag via set_tf_binary(); defaults to autodetection.
+_TF_BINARY: Optional[str] = None
+
+
+def set_tf_binary(engine: str = "auto") -> str:
+    """Resolve and store the Terraform-compatible binary to use.
+
+    Terraform and OpenTofu share an identical CLI for the subcommands
+    Terravision relies on (init, workspace, plan, show -json, graph), so the
+    only difference is the executable name.
+
+    Args:
+        engine: 'terraform', 'tofu', or 'auto'. With 'auto' we prefer
+            'terraform' when present on PATH and fall back to 'tofu'.
+
+    Returns:
+        The resolved binary name.
+    """
+    global _TF_BINARY
+    engine = (engine or "auto").lower()
+    if engine in ("terraform", "tofu"):
+        _TF_BINARY = engine
+    elif shutil.which("terraform"):
+        _TF_BINARY = "terraform"
+    elif shutil.which("tofu"):
+        _TF_BINARY = "tofu"
+    else:
+        # Neither found: keep 'terraform' so check_dependencies reports the
+        # missing-executable error against the default name.
+        _TF_BINARY = "terraform"
+    return _TF_BINARY
+
+
+def get_tf_binary() -> str:
+    """Return the resolved Terraform-compatible binary, autodetecting if unset."""
+    if _TF_BINARY is None:
+        return set_tf_binary("auto")
+    return _TF_BINARY
+
+
 def check_dependencies() -> None:
     """Check if required command-line tools are available."""
-    dependencies = ["dot", "gvpr", "git", "terraform"]
+    dependencies = ["dot", "gvpr", "git", get_tf_binary()]
     bundle_dir = Path(__file__).parent
     import sys
 
@@ -1782,22 +1823,27 @@ def check_dependencies() -> None:
 
 
 def check_terraform_version() -> None:
-    """Validate Terraform version is compatible."""
+    """Validate the Terraform/OpenTofu version is compatible.
+
+    Both engines report a ``v1.x.x`` line (``Terraform v1.x.x`` /
+    ``OpenTofu v1.x.x``), so the same major-version check covers both.
+    """
+    binary = get_tf_binary()
     try:
         result = subprocess.run(
-            ["terraform", "-v"], capture_output=True, text=True, check=True
+            [binary, "-v"], capture_output=True, text=True, check=True
         )
         version_output = result.stdout
 
         version_line = version_output.split("\n")[0]
-        print(f"  terraform version detected: {version_line}")
+        print(f"  {binary} version detected: {version_line}")
         tf_version = version_line.split(" ")[1].replace("v", "")
         version_major = tf_version.split(".")[0]
 
         if version_major != "1":
             click.echo(
                 click.style(
-                    f"\n  ERROR: Terraform Version '{tf_version}' is not supported. Please upgrade to >= v1.0.0",
+                    f"\n  ERROR: {binary} version '{tf_version}' is not supported. Please upgrade to >= v1.0.0",
                     fg="red",
                     bold=True,
                 )
@@ -1806,7 +1852,7 @@ def check_terraform_version() -> None:
     except (subprocess.CalledProcessError, IndexError, FileNotFoundError) as e:
         click.echo(
             click.style(
-                f"\n  ERROR: Failed to check Terraform version: {e}",
+                f"\n  ERROR: Failed to check {binary} version: {e}",
                 fg="red",
                 bold=True,
             )

--- a/modules/tfwrapper.py
+++ b/modules/tfwrapper.py
@@ -205,7 +205,7 @@ def _run_terraform_init(debug, upgrade, skip_reconfigure: bool = False):
     """
     click.echo(click.style("\nCalling Terraform..", fg="white", bold=True))
     click.echo("  Forcing temporary local backend to generate full infrastructure plan")
-    init_cmd = ["terraform", "init"]
+    init_cmd = [helpers.get_tf_binary(), "init"]
     if not skip_reconfigure:
         init_cmd.append("-reconfigure")
     if upgrade:
@@ -226,7 +226,7 @@ def _select_workspace(workspace, debug):
         click.style(f"\nInitalising workspace: {workspace}\n", fg="white", bold=True)
     )
     result = subprocess.run(
-        ["terraform", "workspace", "select", "-or-create=True", workspace],
+        [helpers.get_tf_binary(), "workspace", "select", "-or-create=True", workspace],
         capture_output=not debug,
         text=True,
     )
@@ -241,7 +241,7 @@ def _select_workspace(workspace, debug):
 def _run_terraform_plan(vfiles, tfplan_path, debug):
     """Generate terraform plan binary."""
     click.echo(click.style(f"\nGenerating Terraform Plan..\n", fg="white", bold=True))
-    plan_cmd = ["terraform", "plan", "-refresh=false"]
+    plan_cmd = [helpers.get_tf_binary(), "plan", "-refresh=false"]
     for vf in vfiles:
         plan_cmd.extend(["-var-file", vf])
     plan_cmd.extend(["-out", tfplan_path])
@@ -267,7 +267,7 @@ def _decode_plan(tfplan_path, tfplan_json_path, tfgraph_path, debug):
     # Convert binary plan to JSON
     with open(tfplan_json_path, "w") as f:
         result = subprocess.run(
-            ["terraform", "show", "-json", tfplan_path],
+            [helpers.get_tf_binary(), "show", "-json", tfplan_path],
             stdout=f,
             stderr=None if debug else subprocess.PIPE,
             text=True,
@@ -280,7 +280,7 @@ def _decode_plan(tfplan_path, tfplan_json_path, tfgraph_path, debug):
     # Generate terraform graph
     with open(tfgraph_path, "w") as f:
         result = subprocess.run(
-            ["terraform", "graph"],
+            [helpers.get_tf_binary(), "graph"],
             stdout=f,
             stderr=None if debug else subprocess.PIPE,
             text=True,

--- a/modules/tgwrapper.py
+++ b/modules/tgwrapper.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Tuple
 import click
 import hcl2
 
+import modules.helpers as helpers
 import modules.tfwrapper as tfwrapper
 
 MIN_TERRAGRUNT_VERSION = "0.50.0"
@@ -515,7 +516,7 @@ def _run_terragrunt_init(workdir: str, debug: bool) -> str:
     # override reached the cache. A fresh `-reconfigure` reinitialises
     # the stored state to match the override (local).
     tf_result = subprocess.run(
-        ["terraform", "init", "-reconfigure", "-input=false"],
+        [helpers.get_tf_binary(), "init", "-reconfigure", "-input=false"],
         capture_output=not debug,
         text=True,
         cwd=cache_dir,
@@ -619,7 +620,7 @@ def _decode_tg_plan(
     # Generate plan JSON via terraform show directly in cache
     with open(tfplan_json_path, "w") as f:
         result = subprocess.run(
-            ["terraform", "show", "-json", tfplan_path],
+            [helpers.get_tf_binary(), "show", "-json", tfplan_path],
             stdout=f,
             stderr=None if debug else subprocess.PIPE,
             text=True,
@@ -634,7 +635,7 @@ def _decode_tg_plan(
     # Generate graph DOT
     with open(tfgraph_path, "w") as f:
         result = subprocess.run(
-            ["terraform", "graph"],
+            [helpers.get_tf_binary(), "graph"],
             stdout=f,
             stderr=None if debug else subprocess.PIPE,
             text=True,

--- a/terravision/terravision.py
+++ b/terravision/terravision.py
@@ -306,13 +306,15 @@ def compile_tfdata(
     return tfdata
 
 
-def preflight_check(ai_backend: Optional[str] = None) -> None:
-    """Check required dependencies and Terraform version compatibility.
+def preflight_check(ai_backend: Optional[str] = None, engine: str = "auto") -> None:
+    """Check required dependencies and Terraform/OpenTofu version compatibility.
 
     Args:
         ai_backend: AI backend to validate ('ollama', 'bedrock', or 'restapi')
+        engine: Infra engine to use: 'terraform', 'tofu', or 'auto' (detect).
     """
     click.echo(click.style("\nPreflight check..", fg="white", bold=True))
+    helpers.set_tf_binary(engine)
     helpers.check_dependencies()
     helpers.check_terraform_version()
 
@@ -412,6 +414,13 @@ def cli(ctx) -> None:
     help="Run terraform init with -upgrade to update modules/providers",
 )
 @click.option(
+    "--engine",
+    default="auto",
+    envvar="TERRAVISION_ENGINE",
+    type=click.Choice(["auto", "terraform", "tofu"], case_sensitive=False),
+    help="Infra engine binary: 'terraform', 'tofu' (OpenTofu), or 'auto' (detect). Env: TERRAVISION_ENGINE",
+)
+@click.option(
     "--use-tf-names",
     is_flag=True,
     default=False,
@@ -450,6 +459,7 @@ def draw(
     planfile: str,
     graphfile: str,
     upgrade: bool,
+    engine: str,
     use_tf_names: bool,
     use_resource_names: bool,
     fontsize: int,
@@ -466,7 +476,7 @@ def draw(
                 fg="yellow",
             )
         )
-    preflight_check(ai_annotate if not planfile else None)
+    preflight_check(ai_annotate if not planfile else None, engine=engine)
     tfdata = _safe_compile_tfdata(
         debug,
         source,
@@ -569,6 +579,13 @@ def draw(
     default=False,
     help="Run terraform init with -upgrade to update modules/providers",
 )
+@click.option(
+    "--engine",
+    default="auto",
+    envvar="TERRAVISION_ENGINE",
+    type=click.Choice(["auto", "terraform", "tofu"], case_sensitive=False),
+    help="Infra engine binary: 'terraform', 'tofu' (OpenTofu), or 'auto' (detect). Env: TERRAVISION_ENGINE",
+)
 def graphdata(
     debug: bool,
     source: str,
@@ -583,6 +600,7 @@ def graphdata(
     planfile: str = "",
     graphfile: str = "",
     upgrade: bool = False,
+    engine: str = "auto",
 ) -> None:
     """List cloud resources and relations as drawable JSON."""
     _install_excepthook(debug)
@@ -595,7 +613,7 @@ def graphdata(
                 fg="yellow",
             )
         )
-    preflight_check(ai_annotate if not planfile else None)
+    preflight_check(ai_annotate if not planfile else None, engine=engine)
     tfdata = _safe_compile_tfdata(
         debug,
         source,
@@ -689,6 +707,13 @@ def graphdata(
     help="Run terraform init with -upgrade to update modules/providers",
 )
 @click.option(
+    "--engine",
+    default="auto",
+    envvar="TERRAVISION_ENGINE",
+    type=click.Choice(["auto", "terraform", "tofu"], case_sensitive=False),
+    help="Infra engine binary: 'terraform', 'tofu' (OpenTofu), or 'auto' (detect). Env: TERRAVISION_ENGINE",
+)
+@click.option(
     "--format",
     hidden=True,
     default="",
@@ -736,6 +761,7 @@ def visualise(
     planfile: str,
     graphfile: str,
     upgrade: bool,
+    engine: str,
     format: str,
     ai_annotate: str,
     avl_classes: Any,
@@ -764,7 +790,7 @@ def visualise(
             )
         )
 
-    preflight_check(ai_annotate if not planfile else None)
+    preflight_check(ai_annotate if not planfile else None, engine=engine)
     tfdata = _safe_compile_tfdata(
         debug,
         source,

--- a/tests/helpers_unit_test.py
+++ b/tests/helpers_unit_test.py
@@ -1,4 +1,5 @@
 import unittest, sys, os
+from unittest import mock
 
 # Get the parent directory
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -7,6 +8,7 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 
 from modules.helpers import *
+import modules.helpers as helpers
 
 
 class TestCheckForDomain(unittest.TestCase):
@@ -50,6 +52,63 @@ class TestGetvar(unittest.TestCase):
     def test_getvar_not_found(self):
         result = getvar("not_found", {})
         self.assertEqual(result, "NOTFOUND")
+
+
+class TestTfBinaryResolver(unittest.TestCase):
+    """Resolution of the Terraform-compatible binary (terraform / tofu).
+
+    Given a Terravision invocation with an --engine value,
+    when the binary is resolved,
+    then the correct executable name is stored and returned.
+    """
+
+    def setUp(self):
+        # Each scenario starts with no previously resolved binary.
+        helpers._TF_BINARY = None
+
+    def tearDown(self):
+        helpers._TF_BINARY = None
+
+    def test_should_return_tofu_when_engine_is_tofu(self):
+        # given an explicit tofu engine / when resolved / then tofu is used
+        result = set_tf_binary("tofu")
+        self.assertEqual(result, "tofu")
+        self.assertEqual(get_tf_binary(), "tofu")
+
+    def test_should_return_terraform_when_engine_is_terraform(self):
+        # given an explicit terraform engine / when resolved / then terraform is used
+        result = set_tf_binary("terraform")
+        self.assertEqual(result, "terraform")
+        self.assertEqual(get_tf_binary(), "terraform")
+
+    def test_should_be_case_insensitive_for_explicit_engine(self):
+        # given an uppercase engine name / when resolved / then it is normalised
+        self.assertEqual(set_tf_binary("TOFU"), "tofu")
+
+    def test_should_prefer_terraform_when_auto_and_both_present(self):
+        # given both binaries on PATH / when auto / then terraform wins
+        with mock.patch.object(helpers.shutil, "which", return_value="/usr/bin/x"):
+            self.assertEqual(set_tf_binary("auto"), "terraform")
+
+    def test_should_fall_back_to_tofu_when_auto_and_terraform_absent(self):
+        # given only tofu on PATH / when auto / then tofu is used
+        def which(exe):
+            return "/usr/bin/tofu" if exe == "tofu" else None
+
+        with mock.patch.object(helpers.shutil, "which", side_effect=which):
+            self.assertEqual(set_tf_binary("auto"), "tofu")
+
+    def test_should_default_to_terraform_when_auto_and_neither_present(self):
+        # given neither binary on PATH / when auto / then terraform is reported
+        with mock.patch.object(helpers.shutil, "which", return_value=None):
+            self.assertEqual(set_tf_binary("auto"), "terraform")
+
+    def test_should_autodetect_when_get_called_before_set(self):
+        # given an unset binary / when get is called / then it autodetects via auto
+        with mock.patch.object(
+            helpers.shutil, "which", return_value="/usr/bin/terraform"
+        ):
+            self.assertEqual(get_tf_binary(), "terraform")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 # feat(engine): add OpenTofu support via `--engine` flag

  ## Type of Change

  * [ ] Bug Fix
  * [x] New Feature
  * [ ] Refactor
  * [ ] Documentation

  ## Summary

  Adds first-class [OpenTofu](https://opentofu.org) support as a drop-in alternative to
  Terraform. Terraform and OpenTofu share an identical CLI for every subcommand TerraVision
  relies on (`init`, `workspace`, `plan`, `show -json`, `graph`, `-v`), so the only real
  difference is the executable name.

  **What changed**
  - New binary resolver in `helpers.py` (`set_tf_binary()` / `get_tf_binary()`):
    `auto` prefers `terraform` on `PATH` and falls back to `tofu`, or the engine can be forced.
  - Replaced the **9 hardcoded `"terraform"` invocations** across `tfwrapper.py` and
    `tgwrapper.py` with the resolved binary.
  - Generalised `check_terraform_version()` / `check_dependencies()` to report the active
    engine (both Terraform and OpenTofu are `v1.x`, so the existing major-version check holds).
  - Exposed `--engine [auto|terraform|tofu]` on the `draw`, `visualise` and `graphdata` commands.

  **Why**
  Many teams have migrated from Terraform to OpenTofu after the licence change. Previously the
  binary name was hardcoded, so TerraVision could not run against an OpenTofu-only toolchain.
  This is a low-risk change because the two CLIs are command-compatible.

  **Manual verification**
  Ran `draw` end-to-end with `--engine tofu` (OpenTofu v1.12.1) against a credential-free AWS
  fixture — `tofu init/plan/show -json/graph` all executed correctly and a valid architecture
  diagram was rendered.

  > **Terragrunt note:** the direct `init`/`show`/`graph` calls in `tgwrapper.py` now honour
  > `--engine tofu`, but Terragrunt invokes its own configured binary internally. To make
  > Terragrunt drive OpenTofu, also set `TG_TF_PATH=tofu` (documented in the usage guide).

  ## Checklist

  All Submissions:
  * [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same
  update/change?
  * [x] Have you written Documentation/Tests?
  * [x] Have you done your own code-review?
  * [x] Have you disclosed any use of AI tools and models with their version?

  ## AI Assistance Declaration
  - Tools used: Claude Code
  - Model: Claude Opus 4.8 (1M context)
  - Scope: wrote the BDD unit tests for the resolver.

  ### Checklist for Changes to Core Features:

  * [x] Have you discussed any major revamp with a reviewer/maintainer first? (Minor, additive change —
  defaults to `auto`, so existing Terraform behaviour is unchanged.)
  * [x] Have you ensured your PR is focused on one major improvement and is not trying to do too many changes
  at once?
  * [x] Have you added an explanation of what your changes do and why you'd like us to include them?
  * [x] Have you written new tests for your core changes, as applicable, and made sure the new tests PASS? (7
  BDD scenarios in `tests/helpers_unit_test.py`, 15/15 pass.)
  * [x] Have you successfully run all previous system wide tests with your changes locally?
        (470 passed. The 34 failures are pre-existing and environment-specific — my local
        `terraform` is a tenv wrapper with no version installed, so `terraform -v` exits 42 and
        the integration/visualise tests that shell out to the CLI fail at preflight. Verified the
        identical failures on upstream `main` (b06b9c1) without my changes, so they are not a
        regression. The new resolver tests pass 15/15 and `black --check modules` is clean.)
