### PR TITLE
fix: write Terraform plan artifacts to the run's unique temp dir

### DIFF
--- a/modules/tfwrapper.py
+++ b/modules/tfwrapper.py
@@ -352,7 +352,7 @@ def tf_initplan(
             vf if os.path.isabs(vf) else os.path.join(START_DIR, vf) for vf in varfile
         ]
         # Setup temporary file paths
-        tempdir = os.path.dirname(temp_dir.name)
+        tempdir = temp_dir.name
         tfplan_path = os.path.join(tempdir, "tfplan.bin")
         tfplan_json_path = os.path.join(tempdir, "tfplan.json")
         tfgraph_path = os.path.join(tempdir, "tfgraph.dot")


### PR DESCRIPTION
Fixes #202

## Type of Change

* [x] Bug Fix
* [ ] New Feature
* [ ] Refactor
* [ ] Documentation

## What this changes

`tf_initplan()` in `modules/tfwrapper.py` wrote its plan artifacts (`tfplan.bin`, `tfplan.json`, `tfgraph.dot`) into `os.path.dirname(temp_dir.name)`. `temp_dir` is the per-process `tempfile.TemporaryDirectory`, so taking its parent collapses the path back to the shared temp root (usually `/tmp`). The three artifacts therefore landed at fixed, shared paths.

Run two `terravision` processes at the same time and they write to the same `/tmp/tfplan.bin` (and `.json`/`.dot`), so they overwrite each other's plan and graph partway through a run. In practice this shows up as corrupted or mismatched diagrams when terravision runs concurrently, for example across parallel CI jobs sharing one runner.

The fix uses `temp_dir.name` directly, so each run keeps its artifacts inside its own unique directory.

```diff
-        tempdir = os.path.dirname(temp_dir.name)
+        tempdir = temp_dir.name
```

## Why this is safe

* `temp_dir.name` is already the directory terravision stores as `tfdata["terraform_init_dir"]` (same file, line 371), so the plan artifacts now sit alongside the init data they belong with.
* `_decode_plan()` reads the same three local path variables, so it follows the new location automatically.
* `read_tfsource()` locates modules via `terraform_init_dir`, not these artifact paths, so module resolution is unaffected.
* No public interface or output changes. Behaviour for a single run is identical.

## Testing

* `python -m black --check modules/tfwrapper.py` passes.
* `python -m py_compile modules/tfwrapper.py` passes.
* No automated regression test added. The bug lives inside `tf_initplan()`, where the artifact paths are local variables built inline between real `terraform` subprocess calls, so there is no clean seam to assert on without a small refactor. This PR is kept to the minimal one-line fix on purpose. I am happy to follow up with a refactor that extracts the path construction into a helper plus a regression test if you would prefer that.

## A sibling bug left untouched

`modules/tgwrapper.py` has the same fixed-path pattern for Terragrunt (`/tmp/tg_tfplan.bin` and friends, around line 682). I left it out to keep this PR to a single change, but it is worth a separate fix.

## Checklist

All Submissions:
* [x] Checked for other open PRs covering the same change
* [ ] Written Documentation/Tests (see the Testing note above)
* [x] Done my own code review
* [x] Disclosed AI tool/model use (below)

## AI Assistance Declaration
- Tools used: opencode (CLI coding agent)
- Model: Claude Opus 4 (anthropic/claude-opus-4-8)
- Scope: at the user's request, traced the bug through `tf_initplan` / `_decode_plan` / `read_tfsource`, made the one-line fix, and wrote this PR. 

### Checklist for Changes to Core Features:
* [x] Minor one-line bugfix, raised directly as the template allows for minor fixes
* [x] PR is focused on a single change
* [x] Explanation of what and why is included above
* [ ] New tests not added (rationale in Testing)
* [x] Verified the single-run path by tracing every reader of the changed paths
