### PR TITLE
Point azure/databases.py at the directory its icons ship in

### DIFF
--- a/resource_classes/azure/databases.py
+++ b/resource_classes/azure/databases.py
@@ -3,7 +3,7 @@ from . import _Azure
 
 class _Databases(_Azure):
     _type = "databases"
-    _icon_dir = "resource_images/azure/database"
+    _icon_dir = "resource_images/azure/databases"
 
 
 class AzureCosmosDb(_Databases):

--- a/tests/test_azure_icon_dirs.py
+++ b/tests/test_azure_icon_dirs.py
@@ -1,0 +1,49 @@
+"""
+Regression tests that every Azure resource class points at an icon that exists.
+
+``resource_classes/azure/databases.py`` declared ``resource_images/azure/database``
+while its icons ship under ``resource_images/azure/databases``, so 41 of its 45
+classes resolved to a missing file. Nothing warned about it: the alias resolved,
+so the renderer believed it had an icon and drew an empty node.
+
+``modules.drawing`` loads every module in the package into one namespace, so the
+alphabetically last module wins. That made ``databases.py`` override the working
+aliases in ``database.py``, and broke azurerm_redis_cache and
+azurerm_postgresql_flexible_server for anyone using them.
+"""
+
+import importlib
+import inspect
+import pkgutil
+from pathlib import Path
+
+import pytest
+
+import resource_classes.azure as azure_classes
+
+REPO_ROOT = Path(azure_classes.__file__).parents[2]
+
+
+def _icon_classes():
+    """Every class in resource_classes.azure that declares an icon."""
+    found = []
+    package_path = Path(azure_classes.__file__).parent
+    for _, module_name, _ in pkgutil.iter_modules([str(package_path)]):
+        module = importlib.import_module(f"resource_classes.azure.{module_name}")
+        for name, obj in vars(module).items():
+            if inspect.isclass(obj) and getattr(obj, "_icon", None):
+                found.append(pytest.param(obj, id=f"{module_name}.{name}"))
+    return found
+
+
+ICON_CLASSES = _icon_classes()
+
+
+def test_azure_icon_classes_were_discovered():
+    assert ICON_CLASSES, "no icon classes found; the package layout changed"
+
+
+@pytest.mark.parametrize("icon_class", ICON_CLASSES)
+def test_icon_file_exists(icon_class):
+    icon = REPO_ROOT / icon_class._icon_dir / icon_class._icon
+    assert icon.is_file(), f"{icon_class.__name__} points at missing icon {icon}"


### PR DESCRIPTION
## Problem

`resource_classes/azure/databases.py` declares:

```python
_icon_dir = "resource_images/azure/database"
```

but every icon the module names ships under `resource_images/azure/databases`. **41 of its 45 icon classes resolve to a file that does not exist.** The 4 that work do so only because a same-named file happens to exist in the singular directory.

Nothing reports this. The alias resolves, so the renderer believes it has an icon and draws an empty node — no `no icon for ...` warning is emitted. That makes it invisible unless you look at the rendered diagram.

## Why it affects modules other than this one

`modules/drawing.py` loads every module in the package into one namespace:

```python
for _, module_name, _ in pkgutil.iter_modules([str(package_path)]):
    module = importlib.import_module(full_module_name)
    for name in dir(module):
        if not name.startswith("_"):
            globals()[name] = obj
```

Last module wins, and `databases` sorts after `database`. So `databases.py` overrides the aliases in `database.py` — including `azurerm_redis_cache` and `azurerm_postgresql_flexible_server`, which `database.py` maps to `CacheForRedis` and `DatabaseForPostgresqlServers`, both of whose icons are present and correct.

Net effect: Redis and PostgreSQL Flexible Server render as blank boxes in every Azure diagram, despite having working aliases and icons.

## Change

One character: `database` to `databases` on line 6.

## Tests

Adds `tests/test_azure_icon_dirs.py`, which walks every class in `resource_classes.azure` declaring an `_icon` and asserts the file exists. This catches the whole class of bug, not just this instance.

- With the fix: **1031 passed**
- Reverting only the `_icon_dir` line: **41 failed, 990 passed** — exactly the classes in this module
- `poetry run pytest tests -q -m "not slow"` — 1698 passed, 5 deselected
- `poetry run black --check modules` — 35 files unchanged

## Relationship to #210

Independent. #210 adds missing Terraform aliases for Static Web Apps and Front Door; this fixes a wrong icon directory. Both branches are cut from `main` and neither depends on the other.

## AI assistance disclosed

Per CONTRIBUTING: this change was written with AI assistance (Claude). I reviewed the diff, and the counts above come from running the commands locally rather than being estimated.